### PR TITLE
Limit editor to user PATH variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Environment Variable Editor
 
-A simple PyQt-based GUI for adding, editing, and removing user or system environment variables on Windows 11.
+A simple PyQt-based GUI for viewing and modifying entries in the **user** `PATH` variable on Windows 11.
 
 ## Requirements
 - Python 3
@@ -13,4 +13,4 @@ Run the application on Windows:
 python env_var_editor.py
 ```
 
-The table displays user and system variables. Use **Add**, **Edit**, **Remove**, and **Refresh** buttons to manage variables. Changes are written to the registry and broadcast so new processes receive the updates.
+The table displays the existing entries in the user's `PATH` variable. Use **Add**, **Edit**, **Remove**, and **Refresh** buttons to manage these entries. Changes are written to the registry and broadcast so new processes receive the updates.


### PR DESCRIPTION
## Summary
- simplify editor to show and manage entries of the user PATH variable only
- update README to clarify user PATH focus

## Testing
- `python -m py_compile env_var_editor.py`


------
https://chatgpt.com/codex/tasks/task_e_68af49049768832286d38c1c57a5203e