### PR TITLE
Restore Windows environment variable manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Environment Variable Editor
 
-A simple PyQt-based GUI for viewing and modifying entries in the **user** `PATH` variable on Windows 11.
+A simple PyQt-based GUI for adding, editing, and removing user or system environment variables on Windows 11.
 
 ## Requirements
 - Python 3
@@ -13,4 +13,4 @@ Run the application on Windows:
 python env_var_editor.py
 ```
 
-The table displays the existing entries in the user's `PATH` variable. Use **Add**, **Edit**, **Remove**, and **Refresh** buttons to manage these entries. Changes are written to the registry and broadcast so new processes receive the updates.
+The table displays user and system variables. Use **Add**, **Edit**, **Remove**, and **Refresh** buttons to manage variables. Changes are written to the registry and broadcast so new processes receive the updates.


### PR DESCRIPTION
## Summary
- Revert PATH-only interface to a full environment variable editor
- Allow adding, editing and removing user or system variables
- Update README to describe user/system variable management

## Testing
- `python -m py_compile env_var_editor.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af4b1e69cc83229a5e65b92719f018