### PR TITLE
Add workflow to build executable

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -1,0 +1,32 @@
+name: Build Executable
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller PyQt5
+
+      - name: Build executable
+        run: |
+          pyinstaller --onefile env_var_editor.py
+
+      - name: Upload executable
+        uses: actions/upload-artifact@v3
+        with:
+          name: env_var_editor_exe
+          path: dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+build/
+dist/
+*.spec
+


### PR DESCRIPTION
## Summary
- add manual GitHub Actions workflow to build Windows executable with PyInstaller and upload dist artifact
- ignore common build artifacts

## Testing
- `python -m py_compile env_var_editor.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af6518ba8083228b6e3abe4e0bee31