### PR TITLE
chore: update upload-artifact action

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -26,7 +26,7 @@ jobs:
           pyinstaller --onefile env_var_editor.py
 
       - name: Upload executable
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: env_var_editor_exe
           path: dist


### PR DESCRIPTION
## Summary
- use `actions/upload-artifact@v4` to replace deprecated v3 action

## Testing
- `python -m py_compile env_var_editor.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af66443bbc8322ab222987299c995c