### PR TITLE
Add download link to build workflow

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -30,3 +30,6 @@ jobs:
         with:
           name: env_var_editor_exe
           path: dist
+
+      - name: Show download link
+        run: echo "Download the executable at https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts"


### PR DESCRIPTION
## Summary
- include direct download link to the uploaded executable in the CI workflow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af7b98417883229bad7dcf0e1fab91